### PR TITLE
feat: Rules enablement via code

### DIFF
--- a/datadome-client-go/models.go
+++ b/datadome-client-go/models.go
@@ -31,4 +31,5 @@ type CustomRule struct {
 	Query        string `json:"query"`
 	EndpointType string `json:"endpoint_type"`
 	Priority     string `json:"rule_priority"`
+	Enabled      bool   `json:"rule_enabled"`
 }

--- a/datadome/resource_custom_rule.go
+++ b/datadome/resource_custom_rule.go
@@ -37,6 +37,11 @@ func resourceCustomRule() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
+			"enabled": &schema.Schema{
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  true,
+			},
 		},
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
@@ -56,6 +61,7 @@ func resourceCustomRuleCreate(ctx context.Context, d *schema.ResourceData, m int
 		Query:        d.Get("query").(string),
 		EndpointType: d.Get("endpoint_type").(string),
 		Priority:     d.Get("priority").(string),
+		Enabled:      d.Get("enabled").(bool),
 	}
 
 	o, err := c.CreateCustomRule(newCustomRule)
@@ -90,6 +96,7 @@ func resourceCustomRuleRead(ctx context.Context, d *schema.ResourceData, m inter
 	d.Set("query", customRule.Query)
 	d.Set("endpoint_type", customRule.EndpointType)
 	d.Set("priority", customRule.Priority)
+	d.Set("enabled", customRule.Enabled)
 
 	return diags
 }
@@ -106,6 +113,7 @@ func resourceCustomRuleUpdate(ctx context.Context, d *schema.ResourceData, m int
 		Query:        d.Get("query").(string),
 		EndpointType: d.Get("endpoint_type").(string),
 		Priority:     d.Get("priority").(string),
+		Enabled:      d.Get("enabled").(bool),
 	}
 
 	o, err := c.UpdateCustomRule(newCustomRule)

--- a/docs/resources/custom_rule.md
+++ b/docs/resources/custom_rule.md
@@ -18,6 +18,7 @@ resource "datadome_custom_rule" "new" {
   response      = "whitelist"
   endpoint_type = "web"
   priority      = "normal"
+  enabled       = true
 }
 
 ```
@@ -29,6 +30,7 @@ resource "datadome_custom_rule" "new" {
 - `response` - (Required) The response behavior, must be one of `whitelist`, `captcha`, `block`
 - `endpoint_type` - (Optionnal) The endpoint on which you want your custom rule to be applied. If no endpoint type is specified, the custom rule will be applied to all endpoint types.
 - `priority` - (Optionnal) Your rule priority, must be one of `high`, `low`, `normal`
+- `enabled` - (Optional) Determines whether rule is enabled. Defaults to `true`.
 
 
 ## Attributes Reference


### PR DESCRIPTION
Adds the possibility to control rule enablement via a boolean switch.

Because API **always** returns rule enablement status (`true`/`false`), I decided to set the default.

```json
{
    "id": 12345,
    "rule_name": "Tools",
    "rule_response": "whitelist",
    "query": "ip:1.2.3.4",
    "ip_start": null,
    "ip_end": null,
    "endpoint_type": null,
    "rule_priority": "normal",
    "rule_enabled": true, # Always there
    "hits": null
}
```