### PR TITLE
Fix cross platform build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
         name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.14
+          go-version: 1.16
       -
         name: Import GPG key
         id: import_gpg

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 terraform-provider-datadome
+dist/

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+.PHONY: default build build-all release-local install test testacc clean
+
 TEST?=$$(go list ./... | grep -v 'vendor')
 HOSTNAME=datadome.co
 NAMESPACE=app

--- a/Makefile
+++ b/Makefile
@@ -42,3 +42,6 @@ test:
 
 testacc: 
 	TF_ACC=1 go test $(TEST) -v $(TESTARGS) -timeout 120m
+
+clean:
+	rm -rf ./dist/

--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ release-local:
 
 install: build
 	mkdir -p ~/.terraform.d/plugins/${HOSTNAME}/${NAMESPACE}/${NAME}/${VERSION}/${OS_ARCH}
-	mv ${BINARY} ~/.terraform.d/plugins/${HOSTNAME}/${NAMESPACE}/${NAME}/${VERSION}/${OS_ARCH}
+	mv ${BINARY} ~/.terraform.d/plugins/${OS_ARCH}
 
 test: 
 	go test -i $(TEST) || exit 1

--- a/Makefile
+++ b/Makefile
@@ -11,19 +11,26 @@ default: install
 build:
 	go build -o ${BINARY}
 
-release:
-	GOOS=darwin GOARCH=amd64 go build -o ./bin/${BINARY}_${VERSION}_darwin_amd64
-	GOOS=freebsd GOARCH=386 go build -o ./bin/${BINARY}_${VERSION}_freebsd_386
-	GOOS=freebsd GOARCH=amd64 go build -o ./bin/${BINARY}_${VERSION}_freebsd_amd64
-	GOOS=freebsd GOARCH=arm go build -o ./bin/${BINARY}_${VERSION}_freebsd_arm
-	GOOS=linux GOARCH=386 go build -o ./bin/${BINARY}_${VERSION}_linux_386
-	GOOS=linux GOARCH=amd64 go build -o ./bin/${BINARY}_${VERSION}_linux_amd64
-	GOOS=linux GOARCH=arm go build -o ./bin/${BINARY}_${VERSION}_linux_arm
-	GOOS=openbsd GOARCH=386 go build -o ./bin/${BINARY}_${VERSION}_openbsd_386
-	GOOS=openbsd GOARCH=amd64 go build -o ./bin/${BINARY}_${VERSION}_openbsd_amd64
-	GOOS=solaris GOARCH=amd64 go build -o ./bin/${BINARY}_${VERSION}_solaris_amd64
-	GOOS=windows GOARCH=386 go build -o ./bin/${BINARY}_${VERSION}_windows_386
-	GOOS=windows GOARCH=amd64 go build -o ./bin/${BINARY}_${VERSION}_windows_amd64
+build-all:
+	GOOS=darwin GOARCH=amd64 go build -o ./dist/${BINARY}_${VERSION}_darwin_amd64
+	GOOS=darwin GOARCH=arm64 go build -o ./dist/${BINARY}_${VERSION}_darwin_arm64
+	GOOS=freebsd GOARCH=386 go build -o ./dist/${BINARY}_${VERSION}_freebsd_386
+	GOOS=freebsd GOARCH=amd64 go build -o ./dist/${BINARY}_${VERSION}_freebsd_amd64
+	GOOS=freebsd GOARCH=arm go build -o ./dist/${BINARY}_${VERSION}_freebsd_arm
+	GOOS=freebsd GOARCH=arm64 go build -o ./dist/${BINARY}_${VERSION}_freebsd_arm64
+	GOOS=linux GOARCH=386 go build -o ./dist/${BINARY}_${VERSION}_linux_386
+	GOOS=linux GOARCH=amd64 go build -o ./dist/${BINARY}_${VERSION}_linux_amd64
+	GOOS=linux GOARCH=arm go build -o ./dist/${BINARY}_${VERSION}_linux_arm
+	GOOS=linux GOARCH=arm64 go build -o ./dist/${BINARY}_${VERSION}_linux_arm64
+	GOOS=openbsd GOARCH=386 go build -o ./dist/${BINARY}_${VERSION}_openbsd_386
+	GOOS=openbsd GOARCH=amd64 go build -o ./dist/${BINARY}_${VERSION}_openbsd_amd64
+	GOOS=windows GOARCH=386 go build -o ./dist/${BINARY}_${VERSION}_windows_386
+	GOOS=windows GOARCH=amd64 go build -o ./dist/${BINARY}_${VERSION}_windows_amd64
+	GOOS=windows GOARCH=arm go build -o ./dist/${BINARY}_${VERSION}_windows_arm
+	GOOS=windows GOARCH=arm64 go build -o ./dist/${BINARY}_${VERSION}_windows_arm64
+
+release-local:
+	goreleaser release --snapshot --rm-dist --skip-sign
 
 install: build
 	mkdir -p ~/.terraform.d/plugins/${HOSTNAME}/${NAMESPACE}/${NAME}/${VERSION}/${OS_ARCH}

--- a/datadome-client-go/go.mod
+++ b/datadome-client-go/go.mod
@@ -1,4 +1,3 @@
-
 module github.com/datadome/terraform-provider/datadome-client-go
 
-go 1.13
+go 1.16

--- a/examples/main.tf
+++ b/examples/main.tf
@@ -1,4 +1,5 @@
 terraform {
+  required_version = ">= 0.13.0"
   required_providers {
     datadome = {
       version = "1.0.0"

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/datadome/terraform-provider
 
-go 1.13
+go 1.16
 
 require (
 	github.com/datadome/terraform-provider/datadome-client-go v0.0.0


### PR DESCRIPTION
Fix #8 

There is cross compilation issue with some platform like we experience [here](https://github.com/DataDome/terraform-provider-datadome/runs/6818115664?check_suite_focus=true) with Go 1.14:
```
      • building                 binary=dist/terraform-provider-datadome_linux_arm_6/terraform-provider-datadome_v1.0.1
      • building                 binary=dist/terraform-provider-datadome_darwin_amd64_v1/terraform-provider-datadome_v1.0.1
   ⨯release failed after 248.90serror=failed to build for darwin_arm64: exit status 2: # github.com/datadome/terraform-provider
/opt/hostedtoolcache/go/1.14.15/x64/pkg/tool/linux_amd64/link: running gcc failed: exit status 1
/tmp/go-link-596990799/go.o: file not recognized: file format not recognized
collect2: error: ld returned 1 exit status
```

This problem is known (https://github.com/goreleaser/goreleaser/issues/2066) and can be fixed by upgrade Go.

Furthermore, I include changes useful for tests:
* Align built platforms between makefile and goreleaser
* Add makefile target to run goreleaser
* Fix local installation path