### PR TITLE
fix: update gpg key

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,8 +21,8 @@ jobs:
         uses: crazy-max/ghaction-import-gpg@v5
         id: import_gpg
         with:
-          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
-          passphrase: ${{ secrets.PASSPHRASE }}
+          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY_2 }}
+          passphrase: ${{ secrets.PASSPHRASE_2 }}
 
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v3.0.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,8 +25,8 @@ jobs:
         uses: crazy-max/ghaction-import-gpg@v5
         id: import_gpg
         with:
-          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
-          passphrase: ${{ secrets.PASSPHRASE }}
+          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY_2 }}
+          passphrase: ${{ secrets.PASSPHRASE_2 }}
 
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v3.0.0


### PR DESCRIPTION
The provider is not available anymore on https://registry.terraform.io/providers/DataDome/datadome. As a fix, I created a new gpg key to test the release process.