### PR TITLE
DASBO-7421  upadte authentification to datadome api from query param to using the…

### DIFF
--- a/datadome-client-go/client.go
+++ b/datadome-client-go/client.go
@@ -39,8 +39,9 @@ func (c *Client) doRequest(req *http.Request, httpResponse *HttpResponse) (*Http
 	// Add apikey as a query parameter on each request for authentication
 	// Add also withoutTraffic parameter to true to have better performances
 	q := req.URL.Query()
-	q.Add("apikey", c.Token)
-	q.Add("withoutTraffic", "true")
+	//q.Add("apikey", c.Token)
+	req.Header.Set("x-api-key", "value")
+	q.Add("withoutTraffic", c.Token)
 	req.URL.RawQuery = q.Encode()
 
 	res, err := c.HTTPClient.Do(req)

--- a/datadome-client-go/client.go
+++ b/datadome-client-go/client.go
@@ -39,9 +39,8 @@ func (c *Client) doRequest(req *http.Request, httpResponse *HttpResponse) (*Http
 	// Add apikey as a query parameter on each request for authentication
 	// Add also withoutTraffic parameter to true to have better performances
 	q := req.URL.Query()
-	//q.Add("apikey", c.Token)
-	req.Header.Set("x-api-key", "value")
-	q.Add("withoutTraffic", c.Token)
+	req.Header.Set("x-api-key", c.Token)
+	q.Add("withoutTraffic", "true")
 	req.URL.RawQuery = q.Encode()
 
 	res, err := c.HTTPClient.Do(req)

--- a/datadome-client-go/client.go
+++ b/datadome-client-go/client.go
@@ -36,7 +36,7 @@ func NewClient(host, password *string) (*Client, error) {
 }
 
 func (c *Client) doRequest(req *http.Request, httpResponse *HttpResponse) (*HttpResponse, error) {
-	// Add apikey as a query parameter on each request for authentication
+	// Add apikey as a header on each request for authentication
 	// Add also withoutTraffic parameter to true to have better performances
 	q := req.URL.Query()
 	req.Header.Set("x-api-key", c.Token)


### PR DESCRIPTION
For this Pr we add a new authetication methode with apikey to use in the header as x-api-key,
we keep using the authetificaiton through the queryParam .
both authentication method should be available for customer but we recommend the header method .
documentation is updated .
for more details you can go here [DASBO 7421](https://datadome.atlassian.net/jira/software/projects/DASBO/boards/31?customFilter=ad0fa015-eff2-4e51-bab5-6e75b95ae608&selectedIssue=DASBO-7421)

_**IT**_ SHOULD NOT BE DEPLOYED UNTIL THE DASHBOARD TICKET IS ON PROD