### PR TITLE
fix: update list of allowed endpoint_type values

### DIFF
--- a/datadome/resource_custom_rule.go
+++ b/datadome/resource_custom_rule.go
@@ -3,6 +3,7 @@ package datadome
 import (
 	"context"
 	"fmt"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -85,15 +86,11 @@ func resourceCustomRule() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 				ValidateDiagFunc: func(v any, p cty.Path) diag.Diagnostics {
+					validEnpointTypes := []string{"account-creation", "account-creation-app-mobile", "api", "api-app-mobile", "api-app-mobile-login", "cart", "cart-app-mobile", "forms", "forms-app-mobile", "login", "payment-app-mobile", "payment-web", "rss", "submit", "web"}
 					var diags diag.Diagnostics
 					value := v.(string)
 
-					if !(value == "web" ||
-						value == "api-app-mobile" ||
-						value == "rss" ||
-						value == "api" ||
-						value == "login" ||
-						value == "submit") {
+					if !slices.Contains(validEnpointTypes, value) {
 						diag := diag.Diagnostic{
 							Severity: diag.Error,
 							Summary:  "wrong value",

--- a/docs/resources/custom_rule.md
+++ b/docs/resources/custom_rule.md
@@ -20,7 +20,6 @@ resource "datadome_custom_rule" "new" {
   priority      = "normal"
   enabled       = true
 }
-
 ```
 
 ## Argument Reference


### PR DESCRIPTION
## Description

The list of allowed values for the `endpoint_type` field was not up-to-date on the Terraform provider and on the API Reference.

The list of allowed values has been updated on the API Reference.
This PR updates the list of allowed values accordingly.

This PR closes the issue https://github.com/DataDome/terraform-provider-datadome/issues/30

## How to test?

1. Install the changes on your machine: `make install`
2. Go to the `examples` directory
3. Initialize the Terraform working directory: `terraform init`
4. Attempt the creation of a new custom_rule with one of the following value for the `endpoint_type` field:
  - account-creation
  - account-creation-app-mobile
  - api-app-mobile-login
  - cart
  - cart-app-mobile
  - forms
  - forms-app-mobile
  - payment-app-mobile
  - payment-web

You resource should have been successfully created and should be visible on the Custom rules of your dashboard.