### PR TITLE
chore(release): v2.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # DataDome Terraform Provider
 
+## 2.2.0 (2025-04-02)
+
+### BUG FIXES:
+
+- Update dependencies to fix vulnerabilities
+- Update `Endpoint` structure to fix update issue
+
+### ENHANCEMENTS:
+
+- Add `query` field for `endpoint` management
+- Upgrade `go` version to `1.23`
+
 ## 2.1.0 (2025-02-03)
 
 ### BUG FIXES:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### BUG FIXES:
 
 - Update dependencies to fix vulnerabilities
-- Update `Endpoint` structure to fix update issue
+- Update `Endpoint` structure to fix update issue when fields were omitted from the payload
 
 ### ENHANCEMENTS:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 
 ### ENHANCEMENTS:
 
-- Add `query` field for `endpoint` management
+- Add [`query`](https://docs.datadome.co/docs/endpoints#1-traffic-query) field for `endpoint` management
 - Upgrade `go` version to `1.23`
 
 ## 2.1.0 (2025-02-03)


### PR DESCRIPTION
Release for the `v2.2.0`.

This release includes the following changes:
- #41
- #42 