### PR TITLE
fix: use ID value for the update of custom-rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### BUG FIXES:
 
-- Fix the `Update` method of the `ClientCustomRule`
+- Fix the `Update` method of the `ClientCustomRule` structure
 
 ## 2.2.0 (2025-04-02)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # DataDome Terraform Provider
 
+## 2.2.1 (2025-04-11)
+
+### BUG FIXES:
+
+- Fix the `Update` method of the `ClientCustomRule`
+
 ## 2.2.0 (2025-04-02)
 
 ### BUG FIXES:

--- a/datadome-client-go/client_custom_rule.go
+++ b/datadome-client-go/client_custom_rule.go
@@ -159,7 +159,7 @@ func (c *ClientCustomRule) Update(ctx context.Context, params CustomRule) (*Cust
 	req, err := http.NewRequestWithContext(
 		ctx,
 		"PUT",
-		fmt.Sprintf("%s/%d", c.HostURL, params.ID),
+		fmt.Sprintf("%s/%d", c.HostURL, *params.ID),
 		strings.NewReader(string(rb)),
 	)
 	if err != nil {


### PR DESCRIPTION
## Description

This Pull-Request fix an issue with the `Update` method of the `ClientCustomRule` where the address was passed instead of its value.

## How to test?

1. Install the provider from this branch: `make install`
2. Go in the main.tf and specify your Management API Key in the `provider "datadome"` block
3. Initialize your terraform directory: `terraform init`
4. Create a custom rule in your terraform file.
  For example:
```terraform
resource "datadome_custom_rule" "example_custom_rule" {
  name          = "test-terraform"
  query         = "ip: 192.168.0.1"
  response      = "allow"
  endpoint_type = "web"
  priority      = "normal"
}
```
5. Apply the changes: `terraform apply -autoapprove`
6. Update your custom rule in your terraform file.
  For example:
```terraform
resource "datadome_custom_rule" "example_custom_rule" {
  name          = "test-terraform"
  query         = "ip: 192.168.0.2"
  response      = "allow"
  endpoint_type = "web"
  priority      = "normal"
}
```
7. Apply the changes: `terraform apply -autoapprove`

Your custom rules should have been correctly updated.