### PR TITLE
feat: add activation and expiration dates on custom_rule resource

### DIFF
--- a/common/get_optional_value.go
+++ b/common/get_optional_value.go
@@ -6,14 +6,15 @@ import "github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 // If the fields is set, it returns a pointer of this field.
 // Otherwise, it returns a nil pointer.
 func GetOptionalValue[T comparable](data *schema.ResourceData, field string) *T {
-	var finalValue *T
-	if value, ok := data.GetOk(field); ok {
-		typedValue, ok := value.(T)
-		if !ok {
-			return nil
-		}
-		finalValue = &typedValue
+	value, ok := data.GetOkExists(field)
+	if !ok {
+		return nil
 	}
 
-	return finalValue
+	typedValue, ok := value.(T)
+	if !ok {
+		return nil
+	}
+
+	return &typedValue
 }

--- a/common/get_optional_value.go
+++ b/common/get_optional_value.go
@@ -6,6 +6,7 @@ import "github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 // If the fields is set, it returns a pointer of this field.
 // Otherwise, it returns a nil pointer.
 func GetOptionalValue[T comparable](data *schema.ResourceData, field string) *T {
+	//lint:ignore SA1019 GetOkExists is required for zero-value detection
 	value, ok := data.GetOkExists(field) //nolint:staticcheck
 	if !ok {
 		return nil

--- a/common/get_optional_value.go
+++ b/common/get_optional_value.go
@@ -6,7 +6,7 @@ import "github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 // If the fields is set, it returns a pointer of this field.
 // Otherwise, it returns a nil pointer.
 func GetOptionalValue[T comparable](data *schema.ResourceData, field string) *T {
-	value, ok := data.GetOkExists(field)
+	value, ok := data.GetOkExists(field) //nolint:staticcheck
 	if !ok {
 		return nil
 	}

--- a/common/get_optional_value_test.go
+++ b/common/get_optional_value_test.go
@@ -182,6 +182,7 @@ func TestGetOptionalValue_ZeroValues(t *testing.T) {
 		})
 	}
 }
+
 func TestGetOptionalValue_NullValues(t *testing.T) {
 	tests := []struct {
 		name       string

--- a/common/get_optional_value_test.go
+++ b/common/get_optional_value_test.go
@@ -59,17 +59,48 @@ func TestGetOptionalValue_Bool(t *testing.T) {
 }
 
 func TestGetOptionalValue_MissingField(t *testing.T) {
-	testSchema := map[string]*schema.Schema{
-		"optional_field": {
-			Type:     schema.TypeInt,
-			Optional: true,
+	tests := []struct {
+		name       string
+		schemaType schema.ValueType
+	}{
+		{
+			name:       "missing string field",
+			schemaType: schema.TypeString,
+		},
+		{
+			name:       "missing int field",
+			schemaType: schema.TypeInt,
+		},
+		{
+			name:       "missing bool field",
+			schemaType: schema.TypeBool,
 		},
 	}
 
-	data := schema.TestResourceDataRaw(t, testSchema, map[string]interface{}{})
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			testSchema := map[string]*schema.Schema{
+				"optional_field": {
+					Type:     tt.schemaType,
+					Optional: true,
+				},
+			}
 
-	result := GetOptionalValue[string](data, "optional_field")
-	assert.Nil(t, result)
+			data := schema.TestResourceDataRaw(t, testSchema, map[string]interface{}{})
+
+			switch tt.schemaType {
+			case schema.TypeString:
+				result := GetOptionalValue[string](data, "optional_field")
+				assert.Nil(t, result)
+			case schema.TypeInt:
+				result := GetOptionalValue[int](data, "optional_field")
+				assert.Nil(t, result)
+			case schema.TypeBool:
+				result := GetOptionalValue[bool](data, "optional_field")
+				assert.Nil(t, result)
+			}
+		})
+	}
 }
 
 func TestGetOptionalValue_WrongTypeConversion(t *testing.T) {
@@ -86,4 +117,114 @@ func TestGetOptionalValue_WrongTypeConversion(t *testing.T) {
 
 	result := GetOptionalValue[string](data, "optional_field")
 	assert.Nil(t, result)
+}
+
+func TestGetOptionalValue_ZeroValues(t *testing.T) {
+	tests := []struct {
+		name       string
+		schemaType schema.ValueType
+		value      interface{}
+		expected   interface{}
+	}{
+		{
+			name:       "zero string",
+			schemaType: schema.TypeString,
+			value:      "",
+			expected:   "",
+		},
+		{
+			name:       "zero int",
+			schemaType: schema.TypeInt,
+			value:      0,
+			expected:   0,
+		},
+		{
+			name:       "zero bool",
+			schemaType: schema.TypeBool,
+			value:      false,
+			expected:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			testSchema := map[string]*schema.Schema{
+				"optional_field": {
+					Type:     tt.schemaType,
+					Optional: true,
+				},
+			}
+
+			data := schema.TestResourceDataRaw(t, testSchema, map[string]interface{}{
+				"optional_field": tt.value,
+			})
+
+			switch tt.schemaType {
+			case schema.TypeString:
+				result := GetOptionalValue[string](data, "optional_field")
+				assert.Nil(t, result)
+				t.Log("String type is the only one to return nil for zero value")
+			case schema.TypeInt:
+				result := GetOptionalValue[int](data, "optional_field")
+				assert.NotNil(t, result)
+				if result == nil {
+					t.Fatalf("expected non-nil result for int type")
+				}
+				assert.Equal(t, tt.expected, *result)
+			case schema.TypeBool:
+				result := GetOptionalValue[bool](data, "optional_field")
+				assert.NotNil(t, result)
+				if result == nil {
+					t.Fatalf("expected non-nil result for boolean type")
+				}
+				assert.Equal(t, tt.expected, *result)
+			}
+		})
+	}
+}
+func TestGetOptionalValue_NullValues(t *testing.T) {
+	tests := []struct {
+		name       string
+		schemaType schema.ValueType
+	}{
+		{
+			name:       "null string",
+			schemaType: schema.TypeString,
+		},
+		{
+			name:       "null int",
+			schemaType: schema.TypeInt,
+		},
+		{
+			name:       "null bool",
+			schemaType: schema.TypeBool,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			testSchema := map[string]*schema.Schema{
+				"optional_field": {
+					Type:     tt.schemaType,
+					Optional: true,
+				},
+			}
+
+			data := schema.TestResourceDataRaw(t, testSchema, map[string]interface{}{
+				"optional_field": nil,
+			})
+
+			switch tt.schemaType {
+			case schema.TypeString:
+				result := GetOptionalValue[string](data, "optional_field")
+				assert.Nil(t, result)
+			case schema.TypeInt:
+				result := GetOptionalValue[int](data, "optional_field")
+				assert.Nil(t, result)
+			case schema.TypeBool:
+				result := GetOptionalValue[bool](data, "optional_field")
+				assert.Nil(t, result)
+			}
+		})
+	}
 }

--- a/common/get_optional_value_test.go
+++ b/common/get_optional_value_test.go
@@ -129,8 +129,6 @@ func TestGetOptionalValue_ZeroValues(t *testing.T) {
 		{
 			name:       "zero string",
 			schemaType: schema.TypeString,
-			value:      "",
-			expected:   "",
 		},
 		{
 			name:       "zero int",

--- a/datadome-client-go/models.go
+++ b/datadome-client-go/models.go
@@ -31,13 +31,15 @@ type CustomRules struct {
 
 // CustomRule structure containing the information of a custom rule
 type CustomRule struct {
-	ID           *int   `json:"id"`
-	Name         string `json:"rule_name"`
-	Response     string `json:"rule_response"`
-	Query        string `json:"query"`
-	EndpointType string `json:"endpoint_type"`
-	Priority     string `json:"rule_priority"`
-	Enabled      bool   `json:"rule_enabled"`
+	ID           *int    `json:"id"`
+	Name         string  `json:"rule_name"`
+	Response     string  `json:"rule_response"`
+	Query        string  `json:"query"`
+	EndpointType string  `json:"endpoint_type"`
+	Priority     string  `json:"rule_priority"`
+	Enabled      *bool   `json:"rule_enabled,omitempty"`
+	ActivatedAt  *string `json:"activated_at,omitempty"`
+	ExpiredAt    *string `json:"expired_at,omitempty"`
 }
 
 // Endpoint structure containing the information of an endpoint

--- a/datadome/provider_test.go
+++ b/datadome/provider_test.go
@@ -232,7 +232,7 @@ resource "datadome_custom_rule" "accConfig" {
   response      = "allow"
   endpoint_type = "web"
   priority      = "low"
-  enabled		= true
+  enabled       = true
   activated_at  = "2080-01-31 23:59:59"
   expired_at    = "2099-12-31 23:59:59"
 }
@@ -247,7 +247,7 @@ resource "datadome_custom_rule" "accConfig" {
   response      = "allow"
   endpoint_type = "web"
   priority      = "low"
-  enabled		= true
+  enabled       = true
   expired_at    = "1970-01-01 00:00:00"
 }
 `
@@ -261,7 +261,7 @@ resource "datadome_custom_rule" "accConfig" {
   response      = "allow"
   endpoint_type = "web"
   priority      = "low"
-  enabled		= true
+  enabled       = true
   expired_at    = "1970-01-01 00:00:00"
 }
 `
@@ -275,7 +275,7 @@ resource "datadome_custom_rule" "accConfig" {
   response      = "allow"
   endpoint_type = "web"
   priority      = "low"
-  enabled		= true
+  enabled       = true
   activated_at  = "2099-12-31 23:59:59"
   expired_at    = "2080-01-31 23:59:59"
 }
@@ -290,7 +290,7 @@ resource "datadome_custom_rule" "accConfig" {
   response      = "allow"
   endpoint_type = "web"
   priority      = "low"
-  enabled		= true
+  enabled       = true
   expired_at    = "2019-09-26T07:58:30.996+0200"
 }
 `

--- a/datadome/resource_custom_rule.go
+++ b/datadome/resource_custom_rule.go
@@ -104,6 +104,7 @@ func resourceCustomRule() *schema.Resource {
 			"enabled": {
 				Type:     schema.TypeBool,
 				Optional: true,
+				ForceNew: true,
 			},
 			"activated_at": {
 				Type:     schema.TypeString,

--- a/datadome/resource_custom_rule.go
+++ b/datadome/resource_custom_rule.go
@@ -113,7 +113,7 @@ func resourceCustomRule() *schema.Resource {
 					var diags diag.Diagnostics
 					value := v.(string)
 					if value != "" {
-						parsedTime, err := time.Parse("2006-01-02 15:04:05", value)
+						parsedTime, err := time.Parse(time.DateTime, value)
 						if err != nil {
 							diag := diag.Diagnostic{
 								Severity: diag.Error,
@@ -142,7 +142,7 @@ func resourceCustomRule() *schema.Resource {
 					var diags diag.Diagnostics
 					value := v.(string)
 					if value != "" {
-						parsedTime, err := time.Parse("2006-01-02 15:04:05", value)
+						parsedTime, err := time.Parse(time.DateTime, value)
 						if err != nil {
 							diag := diag.Diagnostic{
 								Severity: diag.Error,
@@ -186,8 +186,8 @@ func customizeDiffCustomRules(ctx context.Context, data *schema.ResourceDiff, me
 	expiredAt := data.Get("expired_at").(string)
 
 	if activatedAt != "" && expiredAt != "" {
-		activatedTime, _ := time.Parse("2006-01-02 15:04:05", activatedAt)
-		expiredTime, _ := time.Parse("2006-01-02 15:04:05", expiredAt)
+		activatedTime, _ := time.Parse(time.DateTime, activatedAt)
+		expiredTime, _ := time.Parse(time.DateTime, expiredAt)
 		if activatedTime.After(expiredTime) {
 			return fmt.Errorf("expired_at date must be after activated_at date")
 		}

--- a/datadome/resource_custom_rule.go
+++ b/datadome/resource_custom_rule.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/datadome/terraform-provider/common"
 	dd "github.com/datadome/terraform-provider/datadome-client-go"
 	"github.com/hashicorp/go-cty/cty"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -103,7 +104,64 @@ func resourceCustomRule() *schema.Resource {
 			"enabled": {
 				Type:     schema.TypeBool,
 				Optional: true,
-				Default:  true,
+			},
+			"activated_at": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ValidateDiagFunc: func(v any, p cty.Path) diag.Diagnostics {
+					var diags diag.Diagnostics
+					value := v.(string)
+					if value != "" {
+						parsedTime, err := time.Parse("2006-01-02 15:04:05", value)
+						if err != nil {
+							diag := diag.Diagnostic{
+								Severity: diag.Error,
+								Summary:  "invalid date format",
+								Detail:   fmt.Sprintf("date '%s' does not match the required format 'YYYY-MM-DD HH:MM:SS'", value),
+							}
+							diags = append(diags, diag)
+						} else {
+							if parsedTime.Before(time.Now().UTC()) {
+								diag := diag.Diagnostic{
+									Severity: diag.Error,
+									Summary:  "invalid date",
+									Detail:   fmt.Sprintf("date '%s' must not be in the past", value),
+								}
+								diags = append(diags, diag)
+							}
+						}
+					}
+					return diags
+				},
+			},
+			"expired_at": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ValidateDiagFunc: func(v any, p cty.Path) diag.Diagnostics {
+					var diags diag.Diagnostics
+					value := v.(string)
+					if value != "" {
+						parsedTime, err := time.Parse("2006-01-02 15:04:05", value)
+						if err != nil {
+							diag := diag.Diagnostic{
+								Severity: diag.Error,
+								Summary:  "invalid date format",
+								Detail:   fmt.Sprintf("date '%s' does not match the required format 'YYYY-MM-DD HH:MM:SS'", value),
+							}
+							diags = append(diags, diag)
+						} else {
+							if parsedTime.Before(time.Now().UTC()) {
+								diag := diag.Diagnostic{
+									Severity: diag.Error,
+									Summary:  "invalid date",
+									Detail:   fmt.Sprintf("date '%s' must not be in the past", value),
+								}
+								diags = append(diags, diag)
+							}
+						}
+					}
+					return diags
+				},
 			},
 		},
 		Importer: &schema.ResourceImporter{
@@ -115,7 +173,26 @@ func resourceCustomRule() *schema.Resource {
 			Update: schema.DefaultTimeout(1 * time.Minute),
 			Delete: schema.DefaultTimeout(1 * time.Minute),
 		},
+		CustomizeDiff: customizeDiffCustomRules,
 	}
+}
+
+// customizeDiffCustomRules applies additional verifications regarding the fields of the custom rule
+// It raises error when:
+// - expired_at is before activated_at
+func customizeDiffCustomRules(ctx context.Context, data *schema.ResourceDiff, meta interface{}) error {
+	activatedAt := data.Get("activated_at").(string)
+	expiredAt := data.Get("expired_at").(string)
+
+	if activatedAt != "" && expiredAt != "" {
+		activatedTime, _ := time.Parse("2006-01-02 15:04:05", activatedAt)
+		expiredTime, _ := time.Parse("2006-01-02 15:04:05", expiredAt)
+		if activatedTime.After(expiredTime) {
+			return fmt.Errorf("expired_at date must be after activated_at date")
+		}
+	}
+
+	return nil
 }
 
 // resourceCustomRuleCreate is used to create new custom rule
@@ -126,13 +203,19 @@ func resourceCustomRuleCreate(ctx context.Context, data *schema.ResourceData, me
 	// Warning or errors can be collected in a slice type
 	var diags diag.Diagnostics
 
+	activatedAt := common.GetOptionalValue[string](data, "activated_at")
+	enabled := common.GetOptionalValue[bool](data, "enabled")
+	expiredAt := common.GetOptionalValue[string](data, "expired_at")
+
 	newCustomRule := dd.CustomRule{
 		Name:         data.Get("name").(string),
 		Response:     data.Get("response").(string),
 		Query:        data.Get("query").(string),
 		EndpointType: data.Get("endpoint_type").(string),
 		Priority:     data.Get("priority").(string),
-		Enabled:      data.Get("enabled").(bool),
+		Enabled:      enabled,
+		ActivatedAt:  activatedAt,
+		ExpiredAt:    expiredAt,
 	}
 
 	id, err := c.Create(ctx, newCustomRule)
@@ -180,6 +263,12 @@ func resourceCustomRuleRead(ctx context.Context, data *schema.ResourceData, meta
 	if err = data.Set("enabled", customRule.Enabled); err != nil {
 		return diag.FromErr(err)
 	}
+	if err = data.Set("activated_at", customRule.ActivatedAt); err != nil {
+		return diag.FromErr(err)
+	}
+	if err = data.Set("expired_at", customRule.ExpiredAt); err != nil {
+		return diag.FromErr(err)
+	}
 
 	return diags
 }
@@ -194,6 +283,10 @@ func resourceCustomRuleUpdate(ctx context.Context, data *schema.ResourceData, me
 		return diag.FromErr(err)
 	}
 
+	activatedAt := common.GetOptionalValue[string](data, "activated_at")
+	enabled := common.GetOptionalValue[bool](data, "enabled")
+	expiredAt := common.GetOptionalValue[string](data, "expired_at")
+
 	newCustomRule := dd.CustomRule{
 		ID:           &id,
 		Name:         data.Get("name").(string),
@@ -201,7 +294,9 @@ func resourceCustomRuleUpdate(ctx context.Context, data *schema.ResourceData, me
 		Query:        data.Get("query").(string),
 		EndpointType: data.Get("endpoint_type").(string),
 		Priority:     data.Get("priority").(string),
-		Enabled:      data.Get("enabled").(bool),
+		Enabled:      enabled,
+		ActivatedAt:  activatedAt,
+		ExpiredAt:    expiredAt,
 	}
 
 	o, err := c.Update(ctx, newCustomRule)

--- a/docs/resources/custom_rule.md
+++ b/docs/resources/custom_rule.md
@@ -11,6 +11,8 @@ Creates a custom rule on DataDome dashboard
 
 ## Example Usage
 
+### Usage with enabled field
+
 ```terraform
 resource "datadome_custom_rule" "new" {
   name          = "my-custom-rule"
@@ -22,6 +24,20 @@ resource "datadome_custom_rule" "new" {
 }
 ```
 
+### Usage with activation and expiration date
+
+```terraform
+resource "datadome_custom_rule" "new" {
+  name          = "my-custom-rule"
+  query         = "ip: 192.168.1.1"
+  response      = "allow"
+  endpoint_type = "web"
+  priority      = "normal"
+  activated_at  = "2030-01-31 23:59:59"
+  expired_at    = "2050-01-31 23:59:59"
+}
+```
+
 ## Argument Reference
 
 - `name` - (Required) Name of your custom rule. You cannot have multiple rules with the same name.
@@ -29,8 +45,9 @@ resource "datadome_custom_rule" "new" {
 - `response` - (Required) The response behavior, must be one of `allow`, `captcha`, `block`
 - `endpoint_type` - (Optional) The endpoint on which you want your custom rule to be applied. If no endpoint type is specified, the custom rule will be applied to all endpoint types.
 - `priority` - (Optional) Your rule priority, must be one of `high`, `low`, `normal`. Defaults to `high`.
-- `enabled` - (Optional) Determines whether rule is enabled. Defaults to `true`.
-
+- `enabled` - (Optional) Determines whether rule is enabled. If its value is set, it will override the value of `activated_at` and `expired_at` fields.
+- `activated_at` - (Optional) Defines the date where the rule will be activated (Format Y-m-d H:i:s UTC+0).
+- `expired_at` - (Optional) Defines the date where the rule will be deactivated (Format Y-m-d H:i:s UTC+0).
 
 ## Attributes Reference
 

--- a/examples/main.tf
+++ b/examples/main.tf
@@ -19,6 +19,8 @@ resource "datadome_custom_rule" "new_custom_rule" {
   response      = "allow"
   endpoint_type = "web"
   priority      = "normal"
+  activated_at  = "2030-01-31 23:59:59"
+  expired_at    = "2050-01-31 23:59:59"
 }
 
 resource "datadome_endpoint" "new_endpoint" {


### PR DESCRIPTION
## Description

The aim of this Pull-Request is to add the feature of the activation and expiration date on Custom Rules.

<!--
Add a short description of what the Pull-Request is achieving (i.e. what features does it bring, what problem does it fix).
-->

## Summary of changes

- Creation of `activated_at` and `expired_at` field in the Custom Rule's schema
- Creation of `ActivatedAt` and `ExpiredAt` fields in `CustomRule` struct
- Remove the default value (`true`) for the `enabled` field when omitted from the Terraform file
- Set the `Enabled` field as optional in the `CustomRule` struct
- Add checks to the `activated_at` and `expired_at` fields to verify that the date is in the right format and not before the current date
- Add a `customizeDiffCustomRules` function to verify that the `activated_at` value is not after the `expired_at` value when both are defined
- Update Terraform's documentation to show example with `enabled` field, and another one with `activated_at` and `expired_at` fields
- The documentation of the `enabled` field has been updated

<!--
Add a non-exhaustive list of the changes in the code.
-->

## How to test?

1. Install the updates of the provider: `make install`
2. Go in the examples directory: `cd examples`
3. Initialize your terraform directory: `terraform init`

You can now perform CRUD operations on custom_rules in your `main.tf` file

<!--
Provide reproduction steps of the feature and explain what should be noticed.
If it is a bug fix, explain the difference before and after the changes.

Precise if there is an Unit and/or End-to-End test to automatically test these changes.
-->
