### PR TITLE
chore: migrate Node-20 actions to Node-24-compatible versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,26 +10,26 @@ jobs:
       contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Unshallow
         run: git fetch --prune --unshallow
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version-file: "go.mod"
           cache: true
 
       - name: Import GPG key
-        uses: crazy-max/ghaction-import-gpg@v6
+        uses: crazy-max/ghaction-import-gpg@v7
         id: import_gpg
         with:
           gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
           passphrase: ${{ secrets.PASSPHRASE }}
 
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v6.0.0
+        uses: goreleaser/goreleaser-action@v7
         with:
           version: "~> v2"
           args: release --snapshot --clean

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,22 +11,22 @@ jobs:
     name: golangci-lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-go@v6
         with:
           go-version-file: "go.mod"
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v7
+        uses: golangci/golangci-lint-action@v9
         with:
           version: v2.11.4
   staticcheck:
     name: staticcheck
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 1
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version-file: "go.mod"
       - uses: dominikh/staticcheck-action@v1.3.1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,26 +12,26 @@ jobs:
       contents: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Unshallow
         run: git fetch --prune --unshallow
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version-file: "go.mod"
           cache: true
 
       - name: Import GPG key
-        uses: crazy-max/ghaction-import-gpg@v6
+        uses: crazy-max/ghaction-import-gpg@v7
         id: import_gpg
         with:
           gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
           passphrase: ${{ secrets.PASSPHRASE }}
 
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v6.0.0
+        uses: goreleaser/goreleaser-action@v7
         with:
           distribution: goreleaser
           version: "~> v2"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,8 +11,8 @@ jobs:
     name: unit tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-go@v6
         with:
           go-version: "1.22"
       - name: run unit tests
@@ -21,8 +21,8 @@ jobs:
     name: acceptance tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-go@v6
         with:
           go-version: "1.22"
       - name: run acceptance tests


### PR DESCRIPTION
Automated migration bumping Node-20 GitHub Actions to Node-24-compatible releases ahead of GitHub's 2026-06-02 forced-runtime cutover.

Changes in this PR:

- `.github/workflows/build.yml`: `actions/checkout@v4` → `actions/checkout@v6`
- `.github/workflows/build.yml`: `actions/setup-go@v5` → `actions/setup-go@v6`
- `.github/workflows/build.yml`: `crazy-max/ghaction-import-gpg@v6` → `crazy-max/ghaction-import-gpg@v7`
- `.github/workflows/build.yml`: `goreleaser/goreleaser-action@v6.0.0` → `goreleaser/goreleaser-action@v7`
- `.github/workflows/lint.yml`: `actions/checkout@v4` → `actions/checkout@v6`
- `.github/workflows/lint.yml`: `actions/setup-go@v5` → `actions/setup-go@v6`
- `.github/workflows/lint.yml`: `golangci/golangci-lint-action@v7` → `golangci/golangci-lint-action@v9`
- `.github/workflows/lint.yml`: `actions/checkout@v4` → `actions/checkout@v6`
- `.github/workflows/lint.yml`: `actions/setup-go@v5` → `actions/setup-go@v6`
- `.github/workflows/release.yml`: `actions/checkout@v4` → `actions/checkout@v6`
- `.github/workflows/release.yml`: `actions/setup-go@v5` → `actions/setup-go@v6`
- `.github/workflows/release.yml`: `crazy-max/ghaction-import-gpg@v6` → `crazy-max/ghaction-import-gpg@v7`
- `.github/workflows/release.yml`: `goreleaser/goreleaser-action@v6.0.0` → `goreleaser/goreleaser-action@v7`
- `.github/workflows/test.yml`: `actions/checkout@v4` → `actions/checkout@v6`
- `.github/workflows/test.yml`: `actions/setup-go@v5` → `actions/setup-go@v6`
- `.github/workflows/test.yml`: `actions/checkout@v4` → `actions/checkout@v6`
- `.github/workflows/test.yml`: `actions/setup-go@v5` → `actions/setup-go@v6`

## Breaking-change analysis

### `.github/workflows/build.yml:13` `actions/checkout` — risk: :green_circle: **NONE**

No breaking-change indicators in release notes; workflow's `with:` keys not mentioned.

Release notes: https://github.com/actions/checkout/compare/v4...v6

### `.github/workflows/build.yml:19` `actions/setup-go` — risk: :yellow_circle: **LOW**

Breaking-change indicators found in release notes, but none of the workflow's `with:` keys appear to be affected.

Release notes: https://github.com/actions/setup-go/compare/v5...v6

### `.github/workflows/build.yml:25` `crazy-max/ghaction-import-gpg` — risk: :green_circle: **NONE**

No breaking-change indicators in release notes; workflow's `with:` keys not mentioned.

Release notes: https://github.com/crazy-max/ghaction-import-gpg/compare/v6...v7

### `.github/workflows/build.yml:32` `goreleaser/goreleaser-action` — risk: :orange_circle: **MEDIUM**

Potential breaking changes detected; manual review recommended.

Release notes: https://github.com/goreleaser/goreleaser-action/compare/v6.0.0...v7

### `.github/workflows/lint.yml:14` `actions/checkout` — risk: :green_circle: **NONE**

No breaking-change indicators in release notes; workflow's `with:` keys not mentioned.

Release notes: https://github.com/actions/checkout/compare/v4...v6

### `.github/workflows/lint.yml:15` `actions/setup-go` — risk: :yellow_circle: **LOW**

Breaking-change indicators found in release notes, but none of the workflow's `with:` keys appear to be affected.

Release notes: https://github.com/actions/setup-go/compare/v5...v6

### `.github/workflows/lint.yml:19` `golangci/golangci-lint-action` — risk: :orange_circle: **MEDIUM**

Potential breaking changes detected; manual review recommended.

Release notes: https://github.com/golangci/golangci-lint-action/compare/v7...v9

### `.github/workflows/lint.yml:26` `actions/checkout` — risk: :green_circle: **NONE**

No breaking-change indicators in release notes; workflow's `with:` keys not mentioned.

Release notes: https://github.com/actions/checkout/compare/v4...v6

### `.github/workflows/lint.yml:29` `actions/setup-go` — risk: :yellow_circle: **LOW**

Breaking-change indicators found in release notes, but none of the workflow's `with:` keys appear to be affected.

Release notes: https://github.com/actions/setup-go/compare/v5...v6

### `.github/workflows/release.yml:15` `actions/checkout` — risk: :green_circle: **NONE**

No breaking-change indicators in release notes; workflow's `with:` keys not mentioned.

Release notes: https://github.com/actions/checkout/compare/v4...v6

### `.github/workflows/release.yml:21` `actions/setup-go` — risk: :yellow_circle: **LOW**

Breaking-change indicators found in release notes, but none of the workflow's `with:` keys appear to be affected.

Release notes: https://github.com/actions/setup-go/compare/v5...v6

### `.github/workflows/release.yml:27` `crazy-max/ghaction-import-gpg` — risk: :green_circle: **NONE**

No breaking-change indicators in release notes; workflow's `with:` keys not mentioned.

Release notes: https://github.com/crazy-max/ghaction-import-gpg/compare/v6...v7

### `.github/workflows/release.yml:34` `goreleaser/goreleaser-action` — risk: :orange_circle: **MEDIUM**

Potential breaking changes detected; manual review recommended.

Release notes: https://github.com/goreleaser/goreleaser-action/compare/v6.0.0...v7

### `.github/workflows/test.yml:14` `actions/checkout` — risk: :green_circle: **NONE**

No breaking-change indicators in release notes; workflow's `with:` keys not mentioned.

Release notes: https://github.com/actions/checkout/compare/v4...v6

### `.github/workflows/test.yml:15` `actions/setup-go` — risk: :yellow_circle: **LOW**

Breaking-change indicators found in release notes, but none of the workflow's `with:` keys appear to be affected.

Release notes: https://github.com/actions/setup-go/compare/v5...v6

### `.github/workflows/test.yml:24` `actions/checkout` — risk: :green_circle: **NONE**

No breaking-change indicators in release notes; workflow's `with:` keys not mentioned.

Release notes: https://github.com/actions/checkout/compare/v4...v6

### `.github/workflows/test.yml:25` `actions/setup-go` — risk: :yellow_circle: **LOW**

Breaking-change indicators found in release notes, but none of the workflow's `with:` keys appear to be affected.

Release notes: https://github.com/actions/setup-go/compare/v5...v6
